### PR TITLE
Account Page - Fixed Incorrect urls in navigation

### DIFF
--- a/frontend-remparts/src/widgets/Header/ui/CatalogMenu/LargeMenu/index.tsx
+++ b/frontend-remparts/src/widgets/Header/ui/CatalogMenu/LargeMenu/index.tsx
@@ -8,7 +8,9 @@ import {
   NavigationMenuViewport,
   Triangle,
 } from '@/shared/ui';
+
 import { Menu } from '../../../types';
+
 import { PopoverRoot } from './PopoverRoot';
 
 type Props = {
@@ -76,7 +78,7 @@ export function LargeMenu({ departments }: Props) {
                             {col.map(cat => (
                               <NavigationMenuLink
                                 key={`col-cat-${cat.name}`}
-                                href={`.././${dep.url}/${cat.url}`}
+                                href={`/${dep.url}/${cat.url}`}
                                 className="px-4 underline-offset-2 hover:underline"
                               >
                                 {cat.name}

--- a/frontend-remparts/src/widgets/Header/ui/CatalogMenu/MobileMenu/index.tsx
+++ b/frontend-remparts/src/widgets/Header/ui/CatalogMenu/MobileMenu/index.tsx
@@ -1,7 +1,10 @@
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button } from '@/shared/ui';
-import { MobileMenuRoot } from './MobileMenuRoot';
-import { Menu } from '../../../types';
 import Link from 'next/link';
+
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button } from '@/shared/ui';
+
+import { Menu } from '../../../types';
+
+import { MobileMenuRoot } from './MobileMenuRoot';
 
 type Props = {
   departments: Menu[];
@@ -34,7 +37,7 @@ export function MobileMenu({ departments }: Props) {
                         className="h-max leading-[1.5] whitespace-normal"
                         asChild
                       >
-                        <Link href={`.././${dep.url}/${cat.url}`}>{cat.name}</Link>
+                        <Link href={`/${dep.url}/${cat.url}`}>{cat.name}</Link>
                       </Button>
                     ))}
                   </div>


### PR DESCRIPTION
Fixed path in nav menu to absolute

` <NavigationMenuLink
     key={`col-cat-${cat.name}`}
     **href={`../.${dep.url}/${cat.url}`}**
     className="px-4 underline-offset-2 hover:underline"
 >
   {cat.name}
</NavigationMenuLink>`

to 
` <NavigationMenuLink
     key={`col-cat-${cat.name}`}
     **href={/${dep.url}/${cat.url}`}**
     className="px-4 underline-offset-2 hover:underline"
 >
   {cat.name}
</NavigationMenuLink>`
